### PR TITLE
Fixed new download URL for github raw files

### DIFF
--- a/plugins/community.applications.plg
+++ b/plugins/community.applications.plg
@@ -1155,7 +1155,7 @@ if [[ -e /tmp/community.applications/tempFiles/templates.json ]]; then rm /tmp/c
 The 'source' file.
 -->
 <FILE Name="/boot/config/plugins/&name;/&name;-&version;-x86_64-1.txz" Run="upgradepkg --install-new">
-<URL>https://raw.github.com/&github;/master/archive/&name;-&version;-x86_64-1.txz</URL>
+<URL>https://github.com/&github;/raw/master/archive/&name;-&version;-x86_64-1.txz</URL>
 <MD5>&md5;</MD5>
 </FILE>
 


### PR DESCRIPTION
Github has changed the raw URL scheme so I have a pull request here that fixes the unable to update issue due to download failure.
I have tested it with a locally modified plg file and it works 😄 