### PR TITLE
Add Podman Manager plugin

### DIFF
--- a/apps.txt
+++ b/apps.txt
@@ -17,3 +17,4 @@
 > To view the policies Community Applications has, click <a href='https://forums.unraid.net/topic/87144-ca-application-policies/' target='_blank'>HERE</a>
 :end
 
+https://github.com/brdweb/podman-manager


### PR DESCRIPTION
## Add Podman Manager

**Repository**: https://github.com/brdweb/podman-manager
**Plugin type**: Unraid WebGUI plugin (Go backend + PHP/jQuery frontend)
**Forum support thread**: https://forums.unraid.net/topic/197728-plugin-podman-manager/

Multi-host Podman container management for Unraid. Connects to remote Podman hosts via SSH and provides a unified dashboard with container lifecycle controls, Quadlet/Compose/standalone detection, bulk actions, and sortable views.